### PR TITLE
Fix race condition in client page camera switch tests

### DIFF
--- a/src/app/client/page.test.tsx
+++ b/src/app/client/page.test.tsx
@@ -1557,6 +1557,13 @@ describe('ClientPage', () => {
       { timeout: 3000 }
     );
 
+    await waitFor(
+      () => {
+        expect(screen.getByRole('button', { name: /Toggle menu/i })).toBeInTheDocument();
+      },
+      { timeout: 3000 }
+    );
+
     const menuButton = screen.getByRole('button', { name: /Toggle menu/i });
     await act(async () => {
       await user.click(menuButton);
@@ -1584,6 +1591,13 @@ describe('ClientPage', () => {
     await waitFor(
       () => {
         expect(navigator.mediaDevices.getUserMedia).toHaveBeenCalled();
+      },
+      { timeout: 3000 }
+    );
+
+    await waitFor(
+      () => {
+        expect(screen.getByRole('button', { name: /Toggle menu/i })).toBeInTheDocument();
       },
       { timeout: 3000 }
     );


### PR DESCRIPTION
## Summary
- Fixed race condition in client page camera switch tests that was causing CI failures
- Added proper waiting for UI elements to render before test interactions
- Aligned test pattern with existing working tests

## Problem
Two tests in `src/app/client/page.test.tsx` were failing in CI:
- `should switch camera from user to environment mode` (line 1545)
- `should switch camera from environment to user mode` (line 1576)

The tests were only waiting for `getUserMedia` to be called but not waiting for the UI to fully render with camera controls. This caused a race condition where the test would try to find the "Toggle menu" button before it was rendered.

## Solution
Added a second `waitFor` block in both failing tests to wait for the "Toggle menu" button to be in the document before attempting to interact with it. This ensures:
1. Camera stream is initialized (getUserMedia called)
2. Component state is updated with the stream
3. UI re-renders with camera controls
4. Only then the test tries to interact with the controls

This pattern was already used in the working test "should switch camera facing mode and update localStorage" (line 292).

## Test Results
All 340 tests now pass with 100% coverage maintained.

🤖 Generated with [Claude Code](https://claude.com/claude-code)