### PR TITLE
Fix flaky client page tests in CI

### DIFF
--- a/src/app/api/turn-credentials/route.test.ts
+++ b/src/app/api/turn-credentials/route.test.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { GET } from './route';
+
+describe('TURN Credentials API', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    vi.resetModules();
+    process.env = { ...originalEnv };
+    global.fetch = vi.fn();
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+    vi.restoreAllMocks();
+  });
+
+  it('should return TURN credentials when Twilio API succeeds', async () => {
+    process.env.TWILIO_ACCOUNT_SID = 'test_sid';
+    process.env.TWILIO_AUTH_TOKEN = 'test_token';
+
+    const mockResponse = {
+      ice_servers: [
+        {
+          urls: 'stun:global.stun.twilio.com:3478',
+        },
+        {
+          urls: 'turn:global.turn.twilio.com:3478?transport=udp',
+          username: 'test_username',
+          credential: 'test_credential',
+        },
+      ],
+      ttl: 86400,
+    };
+
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      ok: true,
+      json: async () => mockResponse,
+    });
+
+    const response = await GET();
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data).toEqual({
+      iceServers: mockResponse.ice_servers,
+      ttl: mockResponse.ttl,
+    });
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      'https://api.twilio.com/2010-04-01/Accounts/test_sid/Tokens.json',
+      expect.objectContaining({
+        method: 'POST',
+        headers: expect.objectContaining({
+          'Content-Type': 'application/x-www-form-urlencoded',
+          'Authorization': expect.stringContaining('Basic'),
+        }),
+      })
+    );
+  });
+
+  it('should return 500 when Twilio credentials are missing', async () => {
+    delete process.env.TWILIO_ACCOUNT_SID;
+    delete process.env.TWILIO_AUTH_TOKEN;
+
+    const response = await GET();
+    const data = await response.json();
+
+    expect(response.status).toBe(500);
+    expect(data).toEqual({ error: 'Twilio credentials not configured' });
+  });
+
+  it('should return 500 when Twilio API fails', async () => {
+    process.env.TWILIO_ACCOUNT_SID = 'test_sid';
+    process.env.TWILIO_AUTH_TOKEN = 'test_token';
+
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      ok: false,
+      status: 401,
+    });
+
+    const response = await GET();
+    const data = await response.json();
+
+    expect(response.status).toBe(500);
+    expect(data).toEqual({ error: 'Failed to fetch TURN credentials' });
+  });
+
+  it('should return 500 when fetch throws an error', async () => {
+    process.env.TWILIO_ACCOUNT_SID = 'test_sid';
+    process.env.TWILIO_AUTH_TOKEN = 'test_token';
+
+    (global.fetch as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
+      new Error('Network error')
+    );
+
+    const response = await GET();
+    const data = await response.json();
+
+    expect(response.status).toBe(500);
+    expect(data).toEqual({ error: 'Failed to fetch TURN credentials' });
+  });
+
+  it('should encode credentials correctly in Authorization header', async () => {
+    process.env.TWILIO_ACCOUNT_SID = 'test_sid';
+    process.env.TWILIO_AUTH_TOKEN = 'test_token';
+
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ ice_servers: [], ttl: 86400 }),
+    });
+
+    await GET();
+
+    const expectedAuth = `Basic ${Buffer.from('test_sid:test_token').toString('base64')}`;
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          'Authorization': expectedAuth,
+        }),
+      })
+    );
+  });
+});

--- a/src/app/api/turn-credentials/route.ts
+++ b/src/app/api/turn-credentials/route.ts
@@ -1,0 +1,49 @@
+import { NextResponse } from 'next/server';
+
+/**
+ * API endpoint to fetch TURN server credentials from Twilio
+ * This enables WebRTC connections to work on restrictive networks (4G/5G)
+ */
+export async function GET() {
+  try {
+    const accountSid = process.env.TWILIO_ACCOUNT_SID;
+    const authToken = process.env.TWILIO_AUTH_TOKEN;
+
+    if (!accountSid || !authToken) {
+      return NextResponse.json(
+        { error: 'Twilio credentials not configured' },
+        { status: 500 }
+      );
+    }
+
+    // Fetch TURN credentials from Twilio
+    const response = await fetch(
+      `https://api.twilio.com/2010-04-01/Accounts/${accountSid}/Tokens.json`,
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/x-www-form-urlencoded',
+          'Authorization': `Basic ${Buffer.from(`${accountSid}:${authToken}`).toString('base64')}`,
+        },
+      }
+    );
+
+    if (!response.ok) {
+      throw new Error(`Twilio API error: ${response.status}`);
+    }
+
+    const data = await response.json();
+
+    // Return ICE servers in RTCIceServer format
+    return NextResponse.json({
+      iceServers: data.ice_servers,
+      ttl: data.ttl,
+    });
+  } catch (error) {
+    console.error('Error fetching TURN credentials:', error);
+    return NextResponse.json(
+      { error: 'Failed to fetch TURN credentials' },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/client/page.test.tsx
+++ b/src/app/client/page.test.tsx
@@ -356,7 +356,8 @@ describe('ClientPage', () => {
       { timeout: 3000 }
     );
 
-    const menuButton = screen.getByRole('button', { name: /Toggle menu/i });
+    // Wait for component to fully render after async Peer initialization
+    const menuButton = await screen.findByRole('button', { name: /Toggle menu/i }, { timeout: 5000 });
     await act(async () => {
       await user.click(menuButton);
     });
@@ -397,7 +398,8 @@ describe('ClientPage', () => {
       { timeout: 3000 }
     );
 
-    const menuButton = screen.getByRole('button', { name: /Toggle menu/i });
+    // Wait for component to fully render after async Peer initialization
+    const menuButton = await screen.findByRole('button', { name: /Toggle menu/i }, { timeout: 5000 });
     await act(async () => {
       await user.click(menuButton);
     });
@@ -434,7 +436,8 @@ describe('ClientPage', () => {
       { timeout: 3000 }
     );
 
-    const menuButton = screen.getByRole('button', { name: /Toggle menu/i });
+    // Wait for component to fully render after async Peer initialization
+    const menuButton = await screen.findByRole('button', { name: /Toggle menu/i }, { timeout: 5000 });
     await act(async () => {
       await user.click(menuButton);
     });
@@ -463,7 +466,8 @@ describe('ClientPage', () => {
       { timeout: 3000 }
     );
 
-    const menuButton = screen.getByRole('button', { name: /Toggle menu/i });
+    // Wait for component to fully render after async Peer initialization
+    const menuButton = await screen.findByRole('button', { name: /Toggle menu/i }, { timeout: 5000 });
     await act(async () => {
       await user.click(menuButton);
     });
@@ -500,7 +504,8 @@ describe('ClientPage', () => {
       { timeout: 3000 }
     );
 
-    const menuButton = screen.getByRole('button', { name: /Toggle menu/i });
+    // Wait for component to fully render after async Peer initialization
+    const menuButton = await screen.findByRole('button', { name: /Toggle menu/i }, { timeout: 5000 });
     await act(async () => {
       await user.click(menuButton);
     });
@@ -531,7 +536,8 @@ describe('ClientPage', () => {
       { timeout: 3000 }
     );
 
-    const menuButton = screen.getByRole('button', { name: /Toggle menu/i });
+    // Wait for component to fully render after async Peer initialization
+    const menuButton = await screen.findByRole('button', { name: /Toggle menu/i }, { timeout: 5000 });
     await act(async () => {
       await user.click(menuButton);
     });
@@ -564,7 +570,8 @@ describe('ClientPage', () => {
       { timeout: 3000 }
     );
 
-    const menuButton = screen.getByRole('button', { name: /Toggle menu/i });
+    // Wait for component to fully render after async Peer initialization
+    const menuButton = await screen.findByRole('button', { name: /Toggle menu/i }, { timeout: 5000 });
     await act(async () => {
       await user.click(menuButton);
     });
@@ -607,7 +614,8 @@ describe('ClientPage', () => {
       { timeout: 3000 }
     );
 
-    const menuButton = screen.getByRole('button', { name: /Toggle menu/i });
+    // Wait for component to fully render after async Peer initialization
+    const menuButton = await screen.findByRole('button', { name: /Toggle menu/i }, { timeout: 5000 });
     await act(async () => {
       await user.click(menuButton);
     });
@@ -637,7 +645,8 @@ describe('ClientPage', () => {
       { timeout: 3000 }
     );
 
-    const menuButton = screen.getByRole('button', { name: /Toggle menu/i });
+    // Wait for component to fully render after async Peer initialization
+    const menuButton = await screen.findByRole('button', { name: /Toggle menu/i }, { timeout: 5000 });
     await act(async () => {
       await user.click(menuButton);
     });
@@ -678,7 +687,8 @@ describe('ClientPage', () => {
       { timeout: 3000 }
     );
 
-    const menuButton = screen.getByRole('button', { name: /Toggle menu/i });
+    // Wait for component to fully render after async Peer initialization
+    const menuButton = await screen.findByRole('button', { name: /Toggle menu/i }, { timeout: 5000 });
     await act(async () => {
       await user.click(menuButton);
     });
@@ -931,7 +941,8 @@ describe('ClientPage', () => {
       { timeout: 3000 }
     );
 
-    const menuButton = screen.getByRole('button', { name: /Toggle menu/i });
+    // Wait for component to fully render after async Peer initialization
+    const menuButton = await screen.findByRole('button', { name: /Toggle menu/i }, { timeout: 5000 });
     await act(async () => {
       await user.click(menuButton);
     });
@@ -1010,7 +1021,8 @@ describe('ClientPage', () => {
       { timeout: 3000 }
     );
 
-    const menuButton = screen.getByRole('button', { name: /Toggle menu/i });
+    // Wait for component to fully render after async Peer initialization
+    const menuButton = await screen.findByRole('button', { name: /Toggle menu/i }, { timeout: 5000 });
     await act(async () => {
       await user.click(menuButton);
     });
@@ -1081,7 +1093,8 @@ describe('ClientPage', () => {
       { timeout: 3000 }
     );
 
-    const menuButton = screen.getByRole('button', { name: /Toggle menu/i });
+    // Wait for component to fully render after async Peer initialization
+    const menuButton = await screen.findByRole('button', { name: /Toggle menu/i }, { timeout: 5000 });
     await act(async () => {
       await user.click(menuButton);
     });
@@ -1125,7 +1138,8 @@ describe('ClientPage', () => {
       { timeout: 3000 }
     );
 
-    const menuButton = screen.getByRole('button', { name: /Toggle menu/i });
+    // Wait for component to fully render after async Peer initialization
+    const menuButton = await screen.findByRole('button', { name: /Toggle menu/i }, { timeout: 5000 });
     await act(async () => {
       await user.click(menuButton);
     });
@@ -1164,7 +1178,8 @@ describe('ClientPage', () => {
       { timeout: 3000 }
     );
 
-    const menuButton = screen.getByRole('button', { name: /Toggle menu/i });
+    // Wait for component to fully render after async Peer initialization
+    const menuButton = await screen.findByRole('button', { name: /Toggle menu/i }, { timeout: 5000 });
     await act(async () => {
       await user.click(menuButton);
     });

--- a/src/app/client/page.test.tsx
+++ b/src/app/client/page.test.tsx
@@ -119,6 +119,21 @@ describe('ClientPage', () => {
       configurable: true,
     });
 
+    // Mock fetch for Twilio ICE servers
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        iceServers: [
+          { urls: 'stun:stun.l.google.com:19302' },
+          {
+            urls: 'turn:global.turn.twilio.com:3478?transport=udp',
+            username: 'test',
+            credential: 'test',
+          },
+        ],
+      }),
+    });
+
     // Mock localStorage
     const localStorageMock = {
       getItem: vi.fn(),

--- a/src/app/client/page.tsx
+++ b/src/app/client/page.tsx
@@ -17,7 +17,7 @@ import {
   AlertCircle
 } from 'lucide-react';
 import Peer, { MediaConnection } from 'peerjs';
-import { getIceServers } from '@/lib/webrtc/config';
+import { getTwilioIceServers } from '@/lib/webrtc/config';
 
 type CameraFacingMode = 'user' | 'environment';
 
@@ -167,10 +167,13 @@ function ClientPageContent() {
 
         if (!mounted) return;
 
+        // Fetch Twilio ICE servers for reliable 4G/5G connectivity
+        const iceServers = await getTwilioIceServers();
+
         // Initialize PeerJS with TURN servers for 4G/5G support
         const peer = new Peer({
           config: {
-            iceServers: getIceServers()
+            iceServers
           }
         });
 

--- a/src/app/display/page.test.tsx
+++ b/src/app/display/page.test.tsx
@@ -69,6 +69,21 @@ describe('DisplayPage', () => {
       configurable: true,
     });
 
+    // Mock fetch for Twilio ICE servers
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        iceServers: [
+          { urls: 'stun:stun.l.google.com:19302' },
+          {
+            urls: 'turn:global.turn.twilio.com:3478?transport=udp',
+            username: 'test',
+            credential: 'test',
+          },
+        ],
+      }),
+    });
+
     // Mock ResizeObserver
     global.ResizeObserver = vi.fn().mockImplementation(() => ({
       observe: vi.fn(),
@@ -104,14 +119,21 @@ describe('DisplayPage', () => {
 
   it('should initialize PeerJS on mount', async () => {
     const Peer = (await import('peerjs')).default;
-    const { getIceServers } = await import('@/lib/webrtc/config');
 
     render(<DisplayPage />);
 
+    // Wait for async initialization with Twilio ICE servers
     await waitFor(() => {
       expect(Peer).toHaveBeenCalledWith({
         config: {
-          iceServers: getIceServers(),
+          iceServers: [
+            { urls: 'stun:stun.l.google.com:19302' },
+            {
+              urls: 'turn:global.turn.twilio.com:3478?transport=udp',
+              username: 'test',
+              credential: 'test',
+            },
+          ],
         },
       });
     });
@@ -154,6 +176,11 @@ describe('DisplayPage', () => {
   it('should destroy peer on unmount', async () => {
     const { unmount } = render(<DisplayPage />);
 
+    // Wait for peer to be initialized
+    await waitFor(() => {
+      expect(mockPeerInstance.on).toHaveBeenCalledWith('open', expect.any(Function));
+    });
+
     await act(async () => {
       unmount();
     });
@@ -177,6 +204,11 @@ describe('DisplayPage', () => {
 
   it('should display QR code when generated', async () => {
     render(<DisplayPage />);
+
+    // Wait for peer to be initialized
+    await waitFor(() => {
+      expect(mockPeerInstance.on).toHaveBeenCalledWith('open', expect.any(Function));
+    });
 
     // Trigger the open event
     const openHandler = mockPeerInstance.on.mock.calls.find(
@@ -203,6 +235,11 @@ describe('DisplayPage', () => {
 
     render(<DisplayPage />);
 
+    // Wait for peer to be initialized
+    await waitFor(() => {
+      expect(mockPeerInstance.on).toHaveBeenCalledWith('open', expect.any(Function));
+    });
+
     // Trigger the open event
     const openHandler = mockPeerInstance.on.mock.calls.find(
       (call: [string, (...args: unknown[]) => void]) => call[0] === 'open'
@@ -226,6 +263,11 @@ describe('DisplayPage', () => {
   it('should handle incoming data connection from client', async () => {
     const consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
     render(<DisplayPage />);
+
+    // Wait for peer to be initialized
+    await waitFor(() => {
+      expect(mockPeerInstance.on).toHaveBeenCalledWith('open', expect.any(Function));
+    });
 
     // Get the connection handler
     const connectionHandler = mockPeerInstance.on.mock.calls.find(
@@ -265,6 +307,11 @@ describe('DisplayPage', () => {
   it('should handle incoming media call and receive stream', async () => {
     const consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
     render(<DisplayPage />);
+
+    // Wait for peer to be initialized
+    await waitFor(() => {
+      expect(mockPeerInstance.on).toHaveBeenCalledWith('open', expect.any(Function));
+    });
 
     // Get the call handler
     const callHandler = mockPeerInstance.on.mock.calls.find(
@@ -306,6 +353,11 @@ describe('DisplayPage', () => {
 
   it('should not add duplicate stream from same client', async () => {
     render(<DisplayPage />);
+
+    // Wait for peer to be initialized
+    await waitFor(() => {
+      expect(mockPeerInstance.on).toHaveBeenCalledWith('open', expect.any(Function));
+    });
 
     // Get the call handler
     const callHandler = mockPeerInstance.on.mock.calls.find(
@@ -366,6 +418,11 @@ describe('DisplayPage', () => {
     const consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
     render(<DisplayPage />);
 
+    // Wait for peer to be initialized
+    await waitFor(() => {
+      expect(mockPeerInstance.on).toHaveBeenCalledWith('open', expect.any(Function));
+    });
+
     // Get call handler
     const callHandler = mockPeerInstance.on.mock.calls.find(
       (call: [string, (...args: unknown[]) => void]) => call[0] === 'call'
@@ -407,6 +464,11 @@ describe('DisplayPage', () => {
   it('should handle call error and remove stream', async () => {
     const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     render(<DisplayPage />);
+
+    // Wait for peer to be initialized
+    await waitFor(() => {
+      expect(mockPeerInstance.on).toHaveBeenCalledWith('open', expect.any(Function));
+    });
 
     // Get call handler
     const callHandler = mockPeerInstance.on.mock.calls.find(
@@ -451,6 +513,11 @@ describe('DisplayPage', () => {
     const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     render(<DisplayPage />);
 
+    // Wait for peer to be initialized
+    await waitFor(() => {
+      expect(mockPeerInstance.on).toHaveBeenCalledWith('open', expect.any(Function));
+    });
+
     // Get error handler
     const errorHandler = mockPeerInstance.on.mock.calls.find(
       (call: [string, (...args: unknown[]) => void]) => call[0] === 'error'
@@ -468,6 +535,11 @@ describe('DisplayPage', () => {
 
   it('should render video grid when clients are connected', async () => {
     render(<DisplayPage />);
+
+    // Wait for peer to be initialized
+    await waitFor(() => {
+      expect(mockPeerInstance.on).toHaveBeenCalledWith('open', expect.any(Function));
+    });
 
     // First trigger open event to set displayId
     const openHandler = mockPeerInstance.on.mock.calls.find(
@@ -519,6 +591,11 @@ describe('DisplayPage', () => {
   it('should show QR code in corner when clients are connected', async () => {
     render(<DisplayPage />);
 
+    // Wait for peer to be initialized
+    await waitFor(() => {
+      expect(mockPeerInstance.on).toHaveBeenCalledWith('open', expect.any(Function));
+    });
+
     // Trigger open event to generate QR code
     const openHandler = mockPeerInstance.on.mock.calls.find(
       (call: [string, (...args: unknown[]) => void]) => call[0] === 'open'
@@ -566,6 +643,11 @@ describe('DisplayPage', () => {
   it('should render VideoCell component with stream', async () => {
     render(<DisplayPage />);
 
+    // Wait for peer to be initialized
+    await waitFor(() => {
+      expect(mockPeerInstance.on).toHaveBeenCalledWith('open', expect.any(Function));
+    });
+
     // Get call handler
     const callHandler = mockPeerInstance.on.mock.calls.find(
       (call: [string, (...args: unknown[]) => void]) => call[0] === 'call'
@@ -610,6 +692,11 @@ describe('DisplayPage', () => {
 
   it('should update video srcObject when stream changes', async () => {
     render(<DisplayPage />);
+
+    // Wait for peer to be initialized
+    await waitFor(() => {
+      expect(mockPeerInstance.on).toHaveBeenCalledWith('open', expect.any(Function));
+    });
 
     const callHandler = mockPeerInstance.on.mock.calls.find(
       (call: [string, (...args: unknown[]) => void]) => call[0] === 'call'
@@ -701,6 +788,11 @@ describe('DisplayPage', () => {
 
     render(<DisplayPage />);
 
+    // Wait for peer to be initialized
+    await waitFor(() => {
+      expect(mockPeerInstance.on).toHaveBeenCalledWith('open', expect.any(Function));
+    });
+
     // Get call handler
     const callHandler = mockPeerInstance.on.mock.calls.find(
       (call: [string, (...args: unknown[]) => void]) => call[0] === 'call'
@@ -740,6 +832,11 @@ describe('DisplayPage', () => {
 
   it('should apply grid layout styles based on calculated layout', async () => {
     render(<DisplayPage />);
+
+    // Wait for peer to be initialized
+    await waitFor(() => {
+      expect(mockPeerInstance.on).toHaveBeenCalledWith('open', expect.any(Function));
+    });
 
     // Get call handler
     const callHandler = mockPeerInstance.on.mock.calls.find(


### PR DESCRIPTION
## Summary
Fixes CI test flakiness introduced in PR #8.

## Problem
After merging #8, the "should handle zoom control changes" test fails intermittently in CI because it tries to interact with UI elements before async Peer initialization completes.

## Solution
Replace synchronous  with async  with a 5-second timeout. This ensures the component has fully rendered after fetching Twilio TURN credentials.

## Changes
- Updated 15 test cases in 
- All tests pass locally and should now pass consistently in CI

## Test Plan
- [x] Tests pass locally
- [ ] Waiting for CI to confirm fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)