### PR TITLE
Add CI/CD caching for Playwright browsers and Next.js builds

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -62,6 +62,16 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Cache Next.js build
+        uses: actions/cache@v4
+        with:
+          path: |
+            .next/cache
+          key: ${{ runner.os }}-nextjs-${{ hashFiles('package-lock.json') }}-${{ hashFiles('**/*.ts', '**/*.tsx', '**/*.js', '**/*.jsx') }}
+          restore-keys: |
+            ${{ runner.os }}-nextjs-${{ hashFiles('package-lock.json') }}-
+            ${{ runner.os }}-nextjs-
+
       - name: Build application
         run: npm run build
 
@@ -134,7 +144,21 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Get Playwright version
+        id: playwright-version
+        run: echo "version=$(npm list @playwright/test --depth=0 --json | jq -r '.dependencies["@playwright/test"].version')" >> $GITHUB_OUTPUT
+
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        id: playwright-cache
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ steps.playwright-version.outputs.version }}
+          restore-keys: |
+            ${{ runner.os }}-playwright-
+
       - name: Install Playwright browsers
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
         run: npx playwright install chromium --with-deps
 
       - name: Run E2E tests


### PR DESCRIPTION
## Summary
- Add Playwright browser caching to E2E job to reduce installation time from ~2m to seconds on cache hits
- Add Next.js build cache to speed up subsequent builds
- Both caches use appropriate cache keys for version/content tracking

## Changes
### Playwright Browser Caching
- Cache directory: `~/.cache/ms-playwright`
- Cache key: Based on OS and Playwright version
- Conditional installation: Only installs browsers on cache miss
- **Expected time savings: ~2 minutes per pipeline run**

### Next.js Build Caching  
- Cache directory: `.next/cache`
- Cache key: Based on package-lock.json and source files
- Improves incremental build performance

## Test Plan
- [x] Verify workflow syntax is valid
- [ ] First run: Cache miss, browsers installed (normal time)
- [ ] Second run: Cache hit, browsers skipped (~2min faster)
- [ ] Verify E2E tests still pass with cached browsers
- [ ] Verify builds work correctly with Next.js cache

🤖 Generated with [Claude Code](https://claude.com/claude-code)